### PR TITLE
Force config fetches to bypass caches

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -286,10 +286,29 @@ const PortalAssetUtils =
       }
     }
 
-    return { resolveUrl };
+    function addCacheBustingQuery(url) {
+      const timestamp = Date.now().toString();
+
+      try {
+        const resolved = new URL(url, determineBaseUrl());
+        resolved.searchParams.set('_', timestamp);
+        return resolved.toString();
+      } catch (error) {
+        try {
+          const resolved = new URL(url, window.location.href);
+          resolved.searchParams.set('_', timestamp);
+          return resolved.toString();
+        } catch (innerError) {
+          const separator = url.includes('?') ? '&' : '?';
+          return `${url}${separator}_${timestamp}`;
+        }
+      }
+    }
+
+    return { resolveUrl, addCacheBustingQuery };
   })());
 
-const { resolveUrl: resolvePortalAssetUrl } = PortalAssetUtils;
+const { resolveUrl: resolvePortalAssetUrl, addCacheBustingQuery } = PortalAssetUtils;
 
 const COLOR_VARIABLE_MAP = {
   pageBackground: '--color-background',
@@ -1075,7 +1094,8 @@ function refreshAdminPreview() {
 }
 
 async function loadConfiguration() {
-  const response = await fetch(resolvePortalAssetUrl('config.json'));
+  const configUrl = addCacheBustingQuery(resolvePortalAssetUrl('config.json'));
+  const response = await fetch(configUrl, { cache: 'no-store' });
   if (!response.ok) {
     throw new Error(`Unable to load config.json (${response.status} ${response.statusText})`);
   }

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,7 +6,6 @@ const APP_SHELL_ASSETS = [
   '/main.js',
   '/admin.html',
   '/admin.js',
-  '/config.json',
   '/manifest.webmanifest',
   '/icons/icon-192.png',
   '/icons/icon-512.png'
@@ -54,7 +53,9 @@ self.addEventListener('fetch', (event) => {
   }
 
   if (requestUrl.pathname === CONFIG_PATH) {
-    event.respondWith(networkFirst(request));
+    event.respondWith(
+      networkFirst(request, { cacheOverride: 'no-store', shouldCache: false })
+    );
     return;
   }
 
@@ -76,15 +77,25 @@ async function handleNavigationRequest(request) {
   }
 }
 
-async function networkFirst(request) {
+async function networkFirst(request, { cacheOverride = 'default', shouldCache = true } = {}) {
   try {
-    const networkResponse = await fetch(request);
-    cacheResponse(request, networkResponse.clone());
+    const fetchOptions = {};
+    if (cacheOverride && cacheOverride !== 'default') {
+      fetchOptions.cache = cacheOverride;
+    }
+    const networkResponse = Object.keys(fetchOptions).length
+      ? await fetch(request, fetchOptions)
+      : await fetch(request);
+    if (shouldCache) {
+      cacheResponse(request, networkResponse.clone());
+    }
     return networkResponse;
   } catch (error) {
-    const cached = await caches.match(request);
-    if (cached) {
-      return cached;
+    if (shouldCache) {
+      const cached = await caches.match(request);
+      if (cached) {
+        return cached;
+      }
     }
     throw error;
   }


### PR DESCRIPTION
## Summary
- add a cache-busting helper so admin and public portals always request a fresh config.json
- prevent the service worker from persisting config.json responses in its cache

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d35e72dfc48322a14d88477c571e75